### PR TITLE
Split layout intro the 2 main categories

### DIFF
--- a/ckanext/dataportaltheme/fanstatic/dataportaltheme.css
+++ b/ckanext/dataportaltheme/fanstatic/dataportaltheme.css
@@ -4,6 +4,12 @@ body {
   font-family: 'Titillium Web', sans-serif;
 }
 
+[role=main],
+.main {
+  background-image: none;
+  background-color: #fff;
+}
+
 #content {
   background-color: #fff;
   position: relative;

--- a/ckanext/dataportaltheme/templates/header.html
+++ b/ckanext/dataportaltheme/templates/header.html
@@ -21,7 +21,7 @@
             <li>
               <a href="/about">Despre</a>
               </li>
- 
+
         </ul>
       </nav>
   <div class="section language">
@@ -71,9 +71,4 @@
     </ul>
   </nav>
   {% endblock %}
-{% endblock %}
-
-{% block header_wrapper %}
-  {{ super() }}
-  {% include "categories_bar.html" %}
 {% endblock %}

--- a/ckanext/dataportaltheme/templates/header_categories.html
+++ b/ckanext/dataportaltheme/templates/header_categories.html
@@ -1,0 +1,6 @@
+{% extends "header.html" %}
+
+{% block header_wrapper %}
+  {{ super() }}
+  {% include "categories_bar.html" %}
+{% endblock %}

--- a/ckanext/dataportaltheme/templates/home/index.html
+++ b/ckanext/dataportaltheme/templates/home/index.html
@@ -1,23 +1,27 @@
-{% ckan_extends %}
+{% extends "page_categories.html" %}
+{% set homepage_style = ( g.homepage_style or '1' ) %}
+
+{% block subtitle %}{{ _("Welcome") }}{% endblock %}
+
+{% block maintag %}{% endblock %}
+{% block toolbar %}{% endblock %}
 
 {% block styles %}
   {{ super() }}
 
-  {# Import example_theme.css using Fanstatic.
-     'dataportaltheme/' is the name that the dataportaltheme/fanstatic directory
-     was registered with when the toolkit.add_resource() function was called.
-     'dataportaltheme.css' is the path to the CSS file, relative to the root of
-     the fanstatic directory. #}
-
-
   {% resource 'dataportaltheme/categories_bar.css' %}
 {% endblock %}
 
-
-{% block primary_content %}
-    {% snippet "home/layout.html".format(homepage_style) %}
-    {% block social %}
-        {% include 'social.html' %}
-    {% endblock social %}
+{% block content %}
+  <div class="homepage layout-{{ homepage_style }}">
+    <div class="container">
+      {{ self.flash() }}
+    </div>
+    {% block primary_content %}
+        {% snippet "home/layout.html".format(homepage_style) %}
+        {% block social %}
+            {% include 'social.html' %}
+        {% endblock social %}
+    {% endblock %}
+  </div>
 {% endblock %}
-

--- a/ckanext/dataportaltheme/templates/page_categories.html
+++ b/ckanext/dataportaltheme/templates/page_categories.html
@@ -1,0 +1,5 @@
+{% extends "page.html" %}
+
+{% block header %}
+    {% include "header_categories.html" %}
+{% endblock %}


### PR DESCRIPTION
We now have page.html for "blank" pages, and page_categories.html for pages that have the big search and categories bar on top of the page.